### PR TITLE
use command -v instead of which in find_program

### DIFF
--- a/kaptive.py
+++ b/kaptive.py
@@ -170,7 +170,7 @@ def check_for_blast():
 
 def find_program(name):
     """Checks to see if a program exists."""
-    process = subprocess.Popen(['which', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(['command -v', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = process.communicate()
     return bool(out) and not bool(err)
 


### PR DESCRIPTION
Hello you may want to use `command -v` instead of `which` 

while testing Kleborate in a minimal docker environement , Kaptive gave me the following error:
```
  File "/opt/gensoft/exe/Kleborate/2.0.0/venv/lib/python3.8/site-packages/kaptive/kaptive.py", line 173, in find_program
    process = subprocess.Popen(['which', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/opt/gensoft/adm/Python/3.8/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/gensoft/adm/Python/3.8/lib/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'which'
```

some more arguments:
`command` is a shell buitin
`command` is posix compliant
`which` is an external binary that may or not available (I admit this may a rare case but it may exists, see above)

regards

Eric
